### PR TITLE
Include non-hunt maps for data loading so they can be used for travel routing

### DIFF
--- a/XIVHuntUtils/Managers/TerritoryManager.cs
+++ b/XIVHuntUtils/Managers/TerritoryManager.cs
@@ -63,7 +63,7 @@ public class TerritoryManager : ITerritoryManager {
 		_log.Debug("Building map data from game files...");
 
 		var supportedMapNames = GetEnumValues<Patch>()
-			.SelectMany(patch => patch.HuntMaps())
+			.SelectMany(patch => patch.HuntMaps().Concat(patch.NonHuntMaps()))
 			.Select(map => map.Name())
 			.ToImmutableHashSet();
 

--- a/XIVHuntUtils/XIVHuntUtils.csproj
+++ b/XIVHuntUtils/XIVHuntUtils.csproj
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/14.0.1">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
 
 	<PropertyGroup Label="feature">
 		<Authors>dit-zy</Authors>
 		<Title>XIV Hunt Utils</Title>
-		<Version>1.6.2</Version>
+		<Version>1.6.3</Version>
 		<Description>a collection of utilities for hunt plugins.</Description>
 		<RepositoryUrl>https://github.com/dit-zy/xiv-hunt-utils</RepositoryUrl>
 		


### PR DESCRIPTION
When TravelNode data is being built for each territory, it requires a territory to be already loaded where the aetheryte is. But the territoryManager was only loading maps that actually had hunts on them, so towns like Idyllshire, etc. were being omitted from the routing decisions.

This also had the weird side effect that if a hinterlands location was included then there was no output whatsoever. I'm not really sure why and I only used 1 hinterlands and 1 non-hinterlands spawn in testing so maybe more/different data would yield a less surprising result.